### PR TITLE
すべてのユーザーが表示されないバグの修正

### DIFF
--- a/src/app/components/preview/preview.component.ts
+++ b/src/app/components/preview/preview.component.ts
@@ -43,7 +43,7 @@ export class PreviewComponent implements OnInit {
     });
 
     this.sliceUsers(userArray.filter((item, index, self) => {
-      return self.map((i) => i.avatar).indexOf(item.avatar) === index;
+      return self.map((i) => `${i.name}${i.avatar}`).indexOf(`${item.name}${item.avatar}`) === index;
     }));
   }
 


### PR DESCRIPTION
## 検証URL
https://connpass.com/event/47492

## バグ内容
画像が設定されていないユーザーが複数人いる場合に2人目が表示されない

## 原因
compassではfacebookやtwitter, githubから連携され各サービスで設定されているアバターを使用すると思います。
しかしこれらを利用していない場合に https://connpass.com/static/img/common/user_no_image.gif の画像が使われるようです。

今回修正した部分にてavatarのurlを指定 `indexOf` でその時のloopのindexとチェックしていたため同じ画像の場合indexが異なるためユーザーとしてピックアップされていなかったようです

今回に関してユーザー情報としてとってきていたnameとavatarを組み合わせてチェックするようにしてみました