### PR TITLE
ユーザー名の表示切れ修正

### DIFF
--- a/src/app/components/card/card.component.css
+++ b/src/app/components/card/card.component.css
@@ -51,6 +51,7 @@
 
 .user-name {
   font-size: 2vh;
+  padding: 2px 2px;
 }
 
 @media print {


### PR DESCRIPTION
お世話になってます!
懇親会などでメンバー把握のために使用させて貰ってます。
今日開催のイベント用に印刷したら、ユーザー名の文字切れを発見したので、修正しました。


![images01](https://cloud.githubusercontent.com/assets/9667078/23933309/070c4d7c-0981-11e7-9125-a5e5aee96bbe.png)
